### PR TITLE
Implement CWAlarm Module for Route53 Healthchecks

### DIFF
--- a/modules/health_check/README.md
+++ b/modules/health_check/README.md
@@ -1,4 +1,4 @@
-# aws-terraform-route53/modules/health_check
+# aws-terraform-route53 - health_check
 
 This module creates Route53 health checks and CloudWatch alarms for a list of fully qualified domain names.
 
@@ -6,7 +6,7 @@ This module creates Route53 health checks and CloudWatch alarms for a list of fu
 
 ```
 module "health_check" {
- source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-route53//modules/health_check/?ref=v0.0.1"
+ source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-route53//modules/health_check/?ref=v0.0.2"
 
  name = "HealthCheck1"
 
@@ -22,15 +22,15 @@ Full working references are available at [examples](examples)
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | alarm\_evaluations | The number of failed evaluations before the CloudWatch alarm is triggered. | string | `"10"` | no |
-| alarms\_enabled | Specifies whether cloudwatch alarms will be created for the health checks. | string | `"false"` | no |
 | domain\_name | A list of domain name or IP addresses to monitor. | list | n/a | yes |
 | domain\_name\_count | The number of domain name or IP addresses to monitor. | string | n/a | yes |
 | environment | Application environment for which this alarm being created. one of: ('Development', 'Integration', 'PreProduction', 'Production', 'QA', 'Staging', 'Test') | string | `"Development"` | no |
 | failure\_threshold | The number of consecutive health checks that an endpoint must pass or fail. | string | `"3"` | no |
 | name | The name prefix for these resources | string | n/a | yes |
-| notification\_topic | SNS Topic ARN to use for customer notifications from CloudWatch alarms. (OPTIONAL) | string | `""` | no |
+| notification\_topic | List of SNS Topic ARNs to use for customer notifications. | list | `<list>` | no |
 | port | The port for the Route53 Healthcheck.  Omit to use the default port for the desired protocol. | string | `"0"` | no |
 | protocol | The port for the Route53 Healthcheck.  Allowed values are HTTP, HTTPS, and TCP. | string | `"HTTP"` | no |
+| rackspace\_alarms\_enabled | Specifies whether alarms will create a Rackspace ticket.  Ignored if rackspace_managed is set to false. | string | `"false"` | no |
 | rackspace\_managed | Boolean parameter controlling if instance will be fully managed by Rackspace support teams, created CloudWatch alarms that generate tickets, and utilize Rackspace managed SSM documents. | string | `"true"` | no |
 | request\_interval | The number of seconds between the finish of one Route 53 health check request and the start of the next. | string | `"30"` | no |
 | resource\_path | Specifies HTTP path to monitor.  The path can be any value which returns an HTTP status code of 2xx or 3xx when the endpoint is healthy.  Ignored for TCP protocol. | string | `"/"` | no |

--- a/modules/health_check/examples/example.tf
+++ b/modules/health_check/examples/example.tf
@@ -4,7 +4,7 @@ provider "aws" {
 }
 
 module "health_check_1" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-route53//modules/health_check/?ref=v0.0.1"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-route53//modules/health_check/?ref=v0.0.2"
 
   name = "HealthCheck1"
 

--- a/modules/health_check/main.tf
+++ b/modules/health_check/main.tf
@@ -1,15 +1,15 @@
 /**
-* # aws-terraform-route53/modules/health_check
-*
-*This module creates Route53 health checks and CloudWatch alarms for a list of fully qualified domain names.
-*
-*## Basic Usage
-*
-*```
-*module "health_check" {
-*  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-route53//modules/health_check/?ref=v0.0.1"
-*
-*  name = "HealthCheck1"
+ * # aws-terraform-route53 - health_check
+ *
+ *This module creates Route53 health checks and CloudWatch alarms for a list of fully qualified domain names.
+ *
+ *## Basic Usage
+ *
+ *```
+ *module "health_check" {
+ *  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-route53//modules/health_check/?ref=v0.0.2"
+ *
+ *  name = "HealthCheck1"
 
 *  domain_name       = ["mysite.com", "subdomain.mysite.com"]
 *  domain_name_count = 2
@@ -20,25 +20,7 @@
 *
 */
 
-data "aws_region" "current" {}
-
-data "aws_caller_identity" "current" {}
-
 locals {
-  rs_alarm_topic         = ["arn:aws:sns:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:rackspace-support-urgent"]
-  alarm_sns_notification = "${compact(list(var.notification_topic))}"
-  rs_alarm_option        = "${var.rackspace_managed ? "managed" : "unmanaged"}"
-
-  rs_alarm_action = {
-    managed   = "${local.rs_alarm_topic}"
-    unmanaged = "${local.alarm_sns_notification}"
-  }
-
-  rs_ok_action = {
-    managed   = "${local.rs_alarm_topic}"
-    unmanaged = []
-  }
-
   healthcheck_type = "${upper(var.protocol)}${var.search_string == "" && upper(var.protocol) != "TCP" ? "" : "_STR_MATCH"}"
   default_port     = "${upper(var.protocol) == "HTTPS" ? 443 : 80}"
 
@@ -67,22 +49,31 @@ resource "aws_route53_health_check" "health_check" {
   )}"
 }
 
-resource "aws_cloudwatch_metric_alarm" "health_check_alarms" {
-  count = "${var.alarms_enabled ? var.domain_name_count : 0}"
+data "null_data_source" "alarm_dimensions" {
+  count = "${var.domain_name_count}"
 
-  alarm_name          = "${var.name}-${element(var.domain_name, count.index)}-Alarm"
-  alarm_actions       = ["${local.rs_alarm_action[local.rs_alarm_option]}"]
-  alarm_description   = "${element(var.domain_name, count.index)} has failed."
-  comparison_operator = "LessThanThreshold"
-  evaluation_periods  = "${var.alarm_evaluations}"
-  metric_name         = "HealthCheckStatus"
-  namespace           = "AWS/Route53"
-  ok_actions          = ["${local.rs_ok_action[local.rs_alarm_option]}"]
-  period              = "60"
-  statistic           = "Minimum"
-  threshold           = "1"
-
-  dimensions {
+  inputs = {
     HealthCheckId = "${element(aws_route53_health_check.health_check.*.id, count.index)}"
   }
+}
+
+module "health_check_alarms" {
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.0.1"
+
+  alarm_count = "${var.domain_name_count}"
+
+  alarm_description        = "Domain healthcheck has failed."
+  alarm_name               = "${var.name}-R53-HealthCheck-Alarm"
+  comparison_operator      = "LessThanThreshold"
+  dimensions               = "${data.null_data_source.alarm_dimensions.*.outputs}"
+  evaluation_periods       = "${var.alarm_evaluations}"
+  metric_name              = "HealthCheckStatus"
+  namespace                = "AWS/Route53"
+  notification_topic       = "${var.notification_topic}"
+  period                   = "60"
+  rackspace_alarms_enabled = "${var.rackspace_alarms_enabled}"
+  rackspace_managed        = "${var.rackspace_managed}"
+  severity                 = "urgent"
+  statistic                = "Minimum"
+  threshold                = "1"
 }

--- a/modules/health_check/variables.tf
+++ b/modules/health_check/variables.tf
@@ -3,12 +3,6 @@ variable "name" {
   type        = "string"
 }
 
-variable "alarms_enabled" {
-  description = "Specifies whether cloudwatch alarms will be created for the health checks."
-  type        = "string"
-  default     = false
-}
-
 variable "alarm_evaluations" {
   description = "The number of failed evaluations before the CloudWatch alarm is triggered."
   type        = "string"
@@ -38,9 +32,9 @@ variable "failure_threshold" {
 }
 
 variable "notification_topic" {
-  description = "SNS Topic ARN to use for customer notifications from CloudWatch alarms. (OPTIONAL)"
-  type        = "string"
-  default     = ""
+  description = "List of SNS Topic ARNs to use for customer notifications."
+  type        = "list"
+  default     = []
 }
 
 variable "port" {
@@ -53,6 +47,12 @@ variable "protocol" {
   description = "The port for the Route53 Healthcheck.  Allowed values are HTTP, HTTPS, and TCP."
   type        = "string"
   default     = "HTTP"
+}
+
+variable "rackspace_alarms_enabled" {
+  description = "Specifies whether alarms will create a Rackspace ticket.  Ignored if rackspace_managed is set to false."
+  type        = "string"
+  default     = false
 }
 
 variable "rackspace_managed" {


### PR DESCRIPTION
##### Corresponding Issue(s) or trello card(s):
https://github.com/rackspace-infrastructure-automation/aws-terraform-internal/issues/191
##### Summary of change(s):

- Replaces `aws_cloudwatch_metric_alarm` resources with calls to the `aws-terraform-cloudwatch_alarm` module.

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
Yes, due to state file path change.

##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
No
##### If input variables or output variables have changed or has been added, have you updated the README?
No variables updated.  Readme example version updated.
##### Do examples need to be updated based on changes?
Example version pinning updated.
##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.