### PR TITLE
Update CW Alarm module pinning to v0.12.6

### DIFF
--- a/modules/health_check/README.md
+++ b/modules/health_check/README.md
@@ -25,6 +25,13 @@ Using [aws-terraform-cloudwatch\_alarm](https://github.com/rackspace-infrastruct
 
 There should be no changes required to move from previous versions of this module to version 0.12.0 or higher.
 
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.12 |
+| aws | >= 2.7.0 |
+
 ## Providers
 
 | Name | Version |
@@ -32,10 +39,23 @@ There should be no changes required to move from previous versions of this modul
 | aws | >= 2.7.0 |
 | null | n/a |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| health_check_alarms | git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.12.6 |  |
+
+## Resources
+
+| Name |
+|------|
+| [aws_route53_health_check](https://registry.terraform.io/providers/hashicorp/aws/2.7.0/docs/resources/route53_health_check) |
+| [null_data_source](https://registry.terraform.io/providers/hashicorp/null/latest/docs/data-sources/data_source) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
+|------|-------------|------|---------|:--------:|
 | alarm\_evaluations | The number of failed evaluations before the CloudWatch alarm is triggered. | `string` | `10` | no |
 | domain\_name | A list of domain name or IP addresses to monitor. | `list(string)` | n/a | yes |
 | domain\_name\_count | The number of domain name or IP addresses to monitor. | `string` | n/a | yes |
@@ -57,4 +77,3 @@ There should be no changes required to move from previous versions of this modul
 | Name | Description |
 |------|-------------|
 | healthcheck\_id | Healthcheck ID |
-

--- a/modules/health_check/main.tf
+++ b/modules/health_check/main.tf
@@ -81,7 +81,7 @@ data "null_data_source" "alarm_dimensions" {
 }
 
 module "health_check_alarms" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.12.4"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.12.6"
 
   alarm_count              = var.domain_name_count
   alarm_description        = "Domain healthcheck has failed."


### PR DESCRIPTION
##### Corresponding Issue(s):
[MPCSUPENG-2116](https://jira.rax.io/browse/MPCSUPENG-2116)

##### Summary of change(s):
Updates pinning of CloudWatch alarm module to v0.12.6 to correct validation errors

##### Reason for Change(s):

- Corrects validation errors introduced due to recent AWS provider updates

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
No
##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
Yes, updates to CW Alarm module
##### If input variables or output variables have changed or has been added, have you updated the README?
NA
##### Do examples need to be updated based on changes?
NA
##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
